### PR TITLE
Adding support for Mathjax for rendering

### DIFF
--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -11,6 +11,7 @@ use hoedown::{AUTOLINK, FENCED_CODE, TABLES, MATH, MATH_EXPLICIT};
 /// - Autolinking email addresses and URLs
 /// - Fenced code blocks
 /// - Tables
+/// - Mathjax support
 pub fn to_html(markdown: &str) -> String {
     let doc = Markdown::new(markdown).extensions(AUTOLINK | FENCED_CODE | TABLES | MATH | MATH_EXPLICIT);
     let mut html = html::Html::new(html::Flags::empty(), 0);

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -2,7 +2,7 @@
 
 use hoedown::renderer::html;
 use hoedown::{Markdown, Render};
-use hoedown::{AUTOLINK, FENCED_CODE, TABLES};
+use hoedown::{AUTOLINK, FENCED_CODE, TABLES, MATH, MATH_EXPLICIT};
 
 /// Renders a markdown string to an HTML string.
 ///
@@ -12,7 +12,7 @@ use hoedown::{AUTOLINK, FENCED_CODE, TABLES};
 /// - Fenced code blocks
 /// - Tables
 pub fn to_html(markdown: &str) -> String {
-    let doc = Markdown::new(markdown).extensions(AUTOLINK | FENCED_CODE | TABLES);
+    let doc = Markdown::new(markdown).extensions(AUTOLINK | FENCED_CODE | TABLES | MATH | MATH_EXPLICIT);
     let mut html = html::Html::new(html::Flags::empty(), 0);
     html.render(&doc).to_str().unwrap().to_string()
 }


### PR DESCRIPTION
Hi, I stumbled across you `https://github.com/euclio/vim-markdown-composer` And it is an interesting proejct. I started to use markdown for report and sometimes I would like to use mathjax as well. So, I was thinking if you would like to add mathjax as default option?
