### PR TITLE
Updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = "1"
 serde_derive = "1"
 staticfile = "0.5"
 url = "1.1.0"
-websocket = { version = "0.21", default-features = false, features = ["sync"] }
+websocket = { version = "0.22", default-features = false, features = ["sync"] }
 
 [dev-dependencies]
 reqwest = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ iron = "0.6"
 lazy_static = "1"
 log = "0.4"
 mount = "0.4"
-pulldown-cmark = { version = "0.4", default-features = false }
+pulldown-cmark = { version = "0.5", default-features = false }
 serde = "1"
 serde_derive = "1"
 staticfile = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ iron = "0.6"
 lazy_static = "1"
 log = "0.4"
 mount = "0.4"
-pulldown-cmark = { version = "0.2", default-features = false }
+pulldown-cmark = { version = "0.4", default-features = false }
 serde = "1"
 serde_derive = "1"
 staticfile = "0.5"

--- a/src/http.rs
+++ b/src/http.rs
@@ -75,7 +75,7 @@ impl Server {
 
         let local_custom_css = local_custom_css
             .into_iter()
-            .flat_map(|file_uri| File::open(file_uri.trim_left_matches("file://")).ok())
+            .flat_map(|file_uri| File::open(file_uri.trim_start_matches("file://")).ok())
             .map(|mut file| {
                 let mut css = String::new();
                 file.read_to_string(&mut css).unwrap();


### PR DESCRIPTION
In particular, the author seems [very excited](https://www.reddit.com/r/rust/comments/bgx1vg/new_pulldowncmark_05_release/) about the `pulldown-cmark` 0.5 release.  Perhaps this would justify a new `aurelius` release?

(Actually my interest is mostly as a user of `vim-markdown-composer` - which is great, by the way! - so if you do go for a new release, it would be nice to see that refreshed too).