### PR TITLE
Fixes #23 pulldown-cmark unicode panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aurelius"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["Andy Russell <arussell123@gmail.com>"]
 documentation = "https://euclio.github.io/aurelius"
 homepage = "https://github.com/euclio/aurelius"
@@ -21,7 +21,7 @@ httparse = "1.3.4"
 include_dir = "0.5.0"
 log = "0.4"
 mime_guess = "2.0.1"
-pulldown-cmark = { version = "0.7.2", default-features = false }
+pulldown-cmark = { version = "0.9.1", default-features = false }
 serde = { version = "1.0.104", features = ["derive"] }
 sha-1 = "0.8.1"
 tungstenite = { version = "0.9.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aurelius"
-version = "0.7.5"
+version = "0.7.4"
 authors = ["Andy Russell <arussell123@gmail.com>"]
 documentation = "https://euclio.github.io/aurelius"
 homepage = "https://github.com/euclio/aurelius"


### PR DESCRIPTION
Unicode chars outside the En / standard set caused panic crash in earlier versions of `pulldown-cmark`

Fixes #23